### PR TITLE
Slim down set of displayed transitions in editor

### DIFF
--- a/src/components/StatesTable.vue
+++ b/src/components/StatesTable.vue
@@ -2,7 +2,6 @@
 import { computed, reactive } from 'vue'
 import { FsmProject } from '@/projects/state-machine/FsmProject'
 import { stateManager } from '@/projects/stateManager'
-import { syncTableToEditor } from '@/utility/fsm/EditorSync/fsmListener'
 import {
   addStateRow as addFsmStateRow,
   getStateCountLimit,
@@ -28,7 +27,6 @@ function addStateRow() {
   if (!current) return
 
   addFsmStateRow(current, fsmModel.value)
-  syncTableToEditor()
 }
 
 function removeStateRow(stateId: number) {

--- a/src/components/StatesTable.vue
+++ b/src/components/StatesTable.vue
@@ -2,6 +2,7 @@
 import { computed, reactive } from 'vue'
 import { FsmProject } from '@/projects/state-machine/FsmProject'
 import { stateManager } from '@/projects/stateManager'
+import { syncTableToEditor } from '@/utility/fsm/EditorSync/fsmListener'
 import {
   addStateRow as addFsmStateRow,
   getStateCountLimit,
@@ -27,6 +28,7 @@ function addStateRow() {
   if (!current) return
 
   addFsmStateRow(current, fsmModel.value)
+  syncTableToEditor()
 }
 
 function removeStateRow(stateId: number) {

--- a/src/panels/FsmEnginePanel.vue
+++ b/src/panels/FsmEnginePanel.vue
@@ -2,7 +2,12 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import type { IDockviewPanelProps } from 'dockview-vue'
 import IframePanel from '@/components/IFramePanel.vue'
-import { setIsSyncing, useFsmListener, forceSyncTableToEditor, consumeSuppressIncomingEditorExport } from '@/utility/fsm/EditorSync/fsmListener'
+import {
+  setIsSyncing,
+  useFsmListener,
+  forceSyncTableToEditor,
+  consumeSuppressIncomingEditorExport,
+} from '@/utility/fsm/EditorSync/fsmListener'
 import { stateManager } from '@/projects/stateManager'
 import { FsmProject } from '@/projects/state-machine/FsmProject'
 
@@ -39,18 +44,20 @@ onMounted(() => {
       if (consumeSuppressIncomingEditorExport()) return
 
       const prevNodes = stateManager.state.fsm?.nodes?.length ?? 0
+      let shouldForce = false
 
       try {
         setIsSyncing(true)
         FsmProject.importEditorExport(data.fsm)
 
         const nextNodes = stateManager.state.fsm?.nodes?.length ?? 0
-        // if the editor added a new node, force a single back-sync of transitions
-        if (nextNodes > prevNodes) {
-          forceSyncTableToEditor()
-        }
+        // mark whether we should force a single back-sync (do it after resetting isSyncing)
+        shouldForce = nextNodes > prevNodes
       } finally {
-        setIsSyncing(false)
+        setTimeout(() => {
+          setIsSyncing(false)
+          if (shouldForce) forceSyncTableToEditor()
+        }, 50)
       }
     }
   }

--- a/src/panels/FsmEnginePanel.vue
+++ b/src/panels/FsmEnginePanel.vue
@@ -2,7 +2,8 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import type { IDockviewPanelProps } from 'dockview-vue'
 import IframePanel from '@/components/IFramePanel.vue'
-import { setIsSyncing, useFsmListener } from '@/utility/fsm/EditorSync/fsmListener'
+import { setIsSyncing, useFsmListener, forceSyncTableToEditor, consumeSuppressIncomingEditorExport } from '@/utility/fsm/EditorSync/fsmListener'
+import { stateManager } from '@/projects/stateManager'
 import { FsmProject } from '@/projects/state-machine/FsmProject'
 
 const props = defineProps<{ params: IDockviewPanelProps }>()
@@ -34,11 +35,22 @@ onMounted(() => {
 
     const data = event.data || {}
     if ((data.action === 'export' || data.action === 'editorToTableExport') && data.fsm) {
+      // if we suppressed the next editor export (because we forced a sync), consume suppression and ignore
+      if (consumeSuppressIncomingEditorExport()) return
+
+      const prevNodes = stateManager.state.fsm?.nodes?.length ?? 0
+
       try {
         setIsSyncing(true)
         FsmProject.importEditorExport(data.fsm)
+
+        const nextNodes = stateManager.state.fsm?.nodes?.length ?? 0
+        // if the editor added a new node, force a single back-sync of transitions
+        if (nextNodes > prevNodes) {
+          forceSyncTableToEditor()
+        }
       } finally {
-        setTimeout(() => setIsSyncing(false), 50)
+        setIsSyncing(false)
       }
     }
   }

--- a/src/utility/fsm/EditorSync/fsmListener.ts
+++ b/src/utility/fsm/EditorSync/fsmListener.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { effectScope, watch, type EffectScope } from 'vue'
+import { effectScope, watch, type EffectScope, nextTick } from 'vue'
 import { stateManager } from '@/projects/stateManager'
 import { calcBinaryID, normalizeBits } from '../bitOperations'
 
@@ -7,8 +7,10 @@ let isSyncing = false
 let isInitialized = false
 let syncScope: EffectScope | null = null
 let iframeReadyHandler: ((event: Event) => void) | null = null
+let suppressIncomingEditorExport = false
+let recentForceSync = false
 
-function syncTableToEditor() {
+export function syncTableToEditor() {
   const newFsm = stateManager.state.fsm
   if (isSyncing || !newFsm) return
 
@@ -52,6 +54,61 @@ function syncTableToEditor() {
   )
 }
 
+// force a single sync to the editor, ignoring the flags
+export function forceSyncTableToEditor(): void {
+  const newFsm = stateManager.state.fsm
+  if (!newFsm) return
+
+  const fsmIframe = (window as any).__fsm_preloaded_iframe
+  if (!fsmIframe?.contentWindow) return
+
+  suppressIncomingEditorExport = true
+  recentForceSync = true
+
+  const editorPayload = {
+    states: newFsm.nodes.map((n) => ({
+      id: n.nodeId,
+      name: n.name,
+      initial: n.isInitial,
+      final: n.isFinal,
+      x: n.editorCoordX,
+      y: n.editorCoordY,
+      moore_output: n.mooreOutput || '',
+    })),
+    transitions: newFsm.transitions.map((t) => ({
+      toBinaryId: normalizeBits(
+        t.toBinaryId ??
+          (t.toNodeId >= 0 ? calcBinaryID(t.toNodeId, newFsm.nodeIdBitCount || 1) : ''),
+        newFsm.nodeIdBitCount || 1,
+        'x',
+        'left',
+      ),
+      id: t.transitionId,
+      from: t.fromNodeId,
+      to: t.toNodeId,
+      input: t.input,
+      output: t.mealyOutput || '',
+      mealy_output: t.mealyOutput || '',
+    })),
+    fsmType: newFsm.fsmModel,
+  }
+
+  fsmIframe.contentWindow.postMessage(
+    {
+      action: 'fsmimport',
+      fsm: editorPayload,
+    },
+    window.location.origin,
+  )
+}
+
+// returns true if the export was suppressed
+export function consumeSuppressIncomingEditorExport(): boolean {
+  const v = suppressIncomingEditorExport
+  suppressIncomingEditorExport = false
+  return v
+}
+
 export function initFsmSyncService() {
   if (isInitialized) {
     syncTableToEditor()
@@ -68,9 +125,16 @@ export function initFsmSyncService() {
   syncScope.run(() => {
     watch(
       () => stateManager.state.fsm,
-      () => {
-        // updates are handled centralized in project
-        syncTableToEditor()
+      async () => {
+        // wait one tick so external callers can toggle `isSyncing`
+        await nextTick()
+        if (recentForceSync) {
+          recentForceSync = false
+          return
+        }
+        if (!isSyncing) {
+          syncTableToEditor()
+        }
       },
       { deep: true },
     )

--- a/src/utility/fsm/EditorSync/fsmListener.ts
+++ b/src/utility/fsm/EditorSync/fsmListener.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { effectScope, watch, type EffectScope, nextTick } from 'vue'
+import { effectScope, watch, type EffectScope } from 'vue'
 import { stateManager } from '@/projects/stateManager'
 import { calcBinaryID, normalizeBits } from '../bitOperations'
 
@@ -8,9 +8,8 @@ let isInitialized = false
 let syncScope: EffectScope | null = null
 let iframeReadyHandler: ((event: Event) => void) | null = null
 let suppressIncomingEditorExport = false
-let recentForceSync = false
 
-export function syncTableToEditor() {
+function syncTableToEditor() {
   const newFsm = stateManager.state.fsm
   if (isSyncing || !newFsm) return
 
@@ -27,21 +26,29 @@ export function syncTableToEditor() {
       y: n.editorCoordY,
       moore_output: n.mooreOutput || '',
     })),
-    transitions: newFsm.transitions.map((t) => ({
-      toBinaryId: normalizeBits(
-        t.toBinaryId ??
-          (t.toNodeId >= 0 ? calcBinaryID(t.toNodeId, newFsm.nodeIdBitCount || 1) : ''),
-        newFsm.nodeIdBitCount || 1,
+    transitions: newFsm.transitions.map((t) => {
+      const nodeBits = newFsm.nodeIdBitCount || 1
+      const inBits = newFsm.inputBitCount || 1
+      const outBits = newFsm.outputBitCount || 1
+      const toBinary = normalizeBits(
+        t.toBinaryId ?? (t.toNodeId >= 0 ? calcBinaryID(t.toNodeId, nodeBits) : ''),
+        nodeBits,
         'x',
         'left',
-      ),
-      id: t.transitionId,
-      from: t.fromNodeId,
-      to: t.toNodeId,
-      input: t.input,
-      output: t.mealyOutput || '',
-      mealy_output: t.mealyOutput || '',
-    })),
+      )
+      const inputNorm = normalizeBits(t.input, inBits, 'x', 'right')
+      const outputNorm = normalizeBits(t.mealyOutput, outBits, 'x', 'right')
+      return {
+        toBinaryId: toBinary,
+        id: t.transitionId,
+        groupId: (t as any).groupId ?? t.transitionId,
+        from: t.fromNodeId,
+        to: t.toNodeId,
+        input: inputNorm,
+        output: outputNorm,
+        mealy_output: outputNorm,
+      }
+    }),
     fsmType: newFsm.fsmModel,
   }
 
@@ -62,8 +69,8 @@ export function forceSyncTableToEditor(): void {
   const fsmIframe = (window as any).__fsm_preloaded_iframe
   if (!fsmIframe?.contentWindow) return
 
+  // mark that the next incoming editor export (in response) should be ignored
   suppressIncomingEditorExport = true
-  recentForceSync = true
 
   const editorPayload = {
     states: newFsm.nodes.map((n) => ({
@@ -125,16 +132,9 @@ export function initFsmSyncService() {
   syncScope.run(() => {
     watch(
       () => stateManager.state.fsm,
-      async () => {
-        // wait one tick so external callers can toggle `isSyncing`
-        await nextTick()
-        if (recentForceSync) {
-          recentForceSync = false
-          return
-        }
-        if (!isSyncing) {
-          syncTableToEditor()
-        }
+      () => {
+        // updates are handled centralized in project
+        syncTableToEditor()
       },
       { deep: true },
     )


### PR DESCRIPTION
Instead of implementing a "hide" button, transitions are reduced by:
- mapping transitions with same output and next state but 0 and 1 as input to x as input
- always hide transitions with output=x*, input=x* and next state=x*